### PR TITLE
Make the MacrosFilter public to be able to inherit from it

### DIFF
--- a/src/main/java/org/jahia/modules/macros/filter/MacrosFilter.java
+++ b/src/main/java/org/jahia/modules/macros/filter/MacrosFilter.java
@@ -76,7 +76,7 @@ import java.util.regex.Pattern;
  * @author rincevent
  * @since JAHIA 6.5
  */
-abstract class MacrosFilter extends AbstractFilter {
+public abstract class MacrosFilter extends AbstractFilter {
 
     private static final Logger logger = LoggerFactory.getLogger(MacrosFilter.class);
 


### PR DESCRIPTION
## Description

Make the MacrosFilter public to be able to inherit from it and create a new one based on some other conditions. Currently the only possibility is to create a new filter and work with composition which is far from ideal.

## Checklist

<!-- 
This section contains a set of non-automated checks, it is there to remind you to think about some business critical topics. 
If some are not applicable they could simply be deleted deleted.
If you need to provide more details, please use the description section.
-->

I have considered the following implications of my change: 

- [V] Security (in particular for changes to authentication, authorization, data fetching, ...)
- [V ] Performance
- [V] Migration
- [V] Code maintainability