### PR TITLE
fix: Sanitize error handling messages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,7 +69,7 @@
     <properties>
         <jahia-module-type>system</jahia-module-type>
         <export-package>org.jahia.modules.macros.filter</export-package>
-        <jahia-module-signature>MC0CFBUcrPp+WpgN5zSoAXYhefK47DgtAhUAj/12TsT3cjaJzv4teo29wd9D6+8=</jahia-module-signature>
+        <jahia-module-signature>MCwCFA9dDVj/p08KztAI+vSU1Q6k3VakAhQ0Syku9w2ma5NiSTI/kGR7ASQh5A==</jahia-module-signature>
     </properties>
 
     <repositories>

--- a/src/main/resources/WEB-INF/modules-macros/resourceBundle.groovy
+++ b/src/main/resources/WEB-INF/modules-macros/resourceBundle.groovy
@@ -1,10 +1,11 @@
 import org.jahia.utils.i18n.JahiaResourceBundle
 
 if(binding.variables.containsKey("param1")){
-    try{
-        print JahiaResourceBundle.getString(binding.variables.containsKey("param2") ? param2 : null, param1, renderContext.getMainResourceLocale(), renderContext.getSite().getTemplatePackageName());
-    }catch(java.util.MissingResourceException e){
-        print param1;
+    try {
+        def bundleName = binding.variables.containsKey("param2") ? param2 : null;
+        print JahiaResourceBundle.getString(bundleName, param1, renderContext.getMainResourceLocale(), renderContext.getSite().getTemplatePackageName());
+    } catch(java.util.MissingResourceException e) {
+        print org.apache.commons.lang.StringEscapeUtils.escapeXml(param1);
     }
 }else{
     print "<p>This macro require one or two parameter like : <br />" +

--- a/src/main/resources/WEB-INF/modules-macros/userprofiledata.groovy
+++ b/src/main/resources/WEB-INF/modules-macros/userprofiledata.groovy
@@ -1,26 +1,19 @@
-/**
- * Created with IntelliJ IDEA.
- * User: Damien GAILLARD
- * Date: 11/8/13
- * Time: 3:27 PM
- */
-if(binding.variables.containsKey("param1")){
+if (binding.variables.containsKey("param1")) {
     if(binding.variables.containsKey("param2")){
         pathUserNode = currentUser.getLocalPath() + "/" + param1;
-        try{
+        try {
             print renderContext.getSite().getSession().getNode(pathUserNode).getProperty(param2).getString();
-        }catch(Exception e){
-            print "Unknown parameter : \"" + e.getMessage() + "\" !";
+        } catch(Exception e) {
+            print org.apache.commons.lang.StringEscapeUtils.escapeXml("Unknown parameter: \"${e.getMessage()}\"!");
         }
+    } else if (currentUser.getUserProperty(param1) == null) {
+        print org.apache.commons.lang.StringEscapeUtils.escapeXml("Unknown parameter: \"${param1}\"!")
+    } else {
+        print currentUser.getUserProperty(param1).getValue();
     }
-    else{
-        if(currentUser.getUserProperty(param1) == null){
-            print "Unknown parameter : \"" + param1 + "\" !";
-        }else{
-            print currentUser.getUserProperty(param1).getValue();
-        }
-    }
-}else{
-    print "<p>This macro require one or two parameter like : <br />" +
-            "## userprofiledata(parameter) ##  or ## userprofiledata(parameter1, parameter2) ##</p>";
+} else {
+    print """
+        <p>This macro requires one or two parameters, like:<br />
+        ## userprofiledata(parameter) ## or ## userprofiledata(parameter1, parameter2) ##</p>
+    """
 }


### PR DESCRIPTION
### Description

Sanitize error handling messages that include params

Note error message for when a macro name is not found does not need additional sanitizing due to the regex already restricting characters to parse macros.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
