### PR TITLE
fix: Update Jahia parent version from 8.1.6.0 to 8.1.6.2

### DIFF
--- a/.chachalog/zecvvON8.md
+++ b/.chachalog/zecvvON8.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+macros: minor
+---
+
+Update compatible Jahia version from 8.1.6.0 to 8.1.6.2 (#57)

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <parent>
         <groupId>org.jahia.modules</groupId>
         <artifactId>jahia-modules</artifactId>
-        <version>8.1.6.0</version>
+        <version>8.1.6.2</version>
     </parent>
 
     <artifactId>macros</artifactId>


### PR DESCRIPTION
### Description
jahia-plugin 6.7 cannot be used at all with jdk 11.0.20 , we need to use 6.8 to be able to build a module with latest jdk (see https://github.com/Jahia/jira-archives/issues/42158#issuecomment-2626886112)

Jahia 8.1.6.2 embeds version 6.8