### PR TITLE
fix: escape keyword values rendered by the keywords macro

### DIFF
--- a/.chachalog/d5Rn7kTq.md
+++ b/.chachalog/d5Rn7kTq.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+macros: patch
+---
+
+Fixed display of keyword values containing special characters rendered by the keywords macro.

--- a/src/main/resources/WEB-INF/modules-macros/keywords.groovy
+++ b/src/main/resources/WEB-INF/modules-macros/keywords.groovy
@@ -8,7 +8,7 @@ if(currentNode.hasProperty("j:keywords")){
     keywords = currentNode.getProperty("j:keywords").getValues();
     keywordsSize =  keywords.size();
     for(int i = 0 ; i < keywordsSize ; i++){
-        print keywords.value[i].getString();
+        print org.apache.commons.lang.StringEscapeUtils.escapeXml(keywords.value[i].getString());
         if(keywordsSize > 0 && i < keywordsSize-1){
             print ", ";
         }


### PR DESCRIPTION
### Summary
The `keywords` macro (`##keywords##`) printed each `j:keywords` value **without escaping**, so keyword values containing special characters (`<`, `>`, `&`, quotes) could be rendered incorrectly on the delivered (guest) page.

### Change
`keywords.groovy` now wraps the printed keyword value in `org.apache.commons.lang.StringEscapeUtils.escapeXml(...)` (the encoder already used elsewhere in Jahia core). No-op for plain-text keywords.

### Verification
Deploy-tested on a local 8.2.x instance with a clean **before/after** (guest render of a page embedding `##keywords##`): the baseline build rendered a keyword containing special characters raw; this branch renders it correctly escaped.
