### PR TITLE
fix: Escape keywords rendering

### DIFF
--- a/.chachalog/rFWB8slY.md
+++ b/.chachalog/rFWB8slY.md
@@ -1,0 +1,6 @@
+---
+# Allowed version bumps: patch, minor, major
+macros: patch
+---
+
+##keywords## macro now HTML-escapes `j:keywords` values before rendering (#68)

--- a/src/main/resources/WEB-INF/modules-macros/keywords.groovy
+++ b/src/main/resources/WEB-INF/modules-macros/keywords.groovy
@@ -1,20 +1,14 @@
-/**
- * Created with IntelliJ IDEA.
- * User: Damien GAILLARD
- * Date: 11/8/13
- * Time: 9:28 AM
- */
+import org.apache.commons.lang.StringEscapeUtils
+
 if(currentNode.hasProperty("j:keywords")){
     keywords = currentNode.getProperty("j:keywords").getValues();
     keywordsSize =  keywords.size();
     for(int i = 0 ; i < keywordsSize ; i++){
-        print keywords.value[i].getString();
+        print StringEscapeUtils.escapeHtml(keywords.value[i].getString());
         if(keywordsSize > 0 && i < keywordsSize-1){
             print ", ";
         }
     }
-}else{
+} else {
     print "Defined Keyword(s) before use !";
 }
-
-


### PR DESCRIPTION
### Description

Escape html rendering of ##keywords## macro and prevent rendering of special characters.

### Checklist
#### Source code
- [ ] I've shared and documented any breaking change
- [ ] I've reviewed and updated the jahia-depends

#### Tests
- [ ] I've provided Unit and/or Integration Tests
- [ ] I've updated the parent issue with required manual validations

> [!TIP]
> Documentation to guide the reviews: [How to do a code review](https://jahia-confluence.atlassian.net/wiki/spaces/PR/pages/2064660/How+to+do+a+code+review+-+Ref+ISSOP08.A14006)
